### PR TITLE
minified image + minor fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,8 @@ downloads/*
 snapshots/*
 settings.json
 node_modules
-npm-debug.log
+*.log
+Dockerfile*
+Makefile
+README*
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,24 @@
-FROM node:10
-
-RUN apt-get update && apt-get install -y wget mysql-client
-
-ENV DOCKERIZE_VERSION v0.6.1
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+FROM node:10-alpine
 
 WORKDIR /usr/idexd/
+
 COPY package*.json ./
-RUN npm install -g pm2
-RUN npm install -g sequelize
-RUN npm install
+RUN apk --no-cache --virtual build-dependencies add python git make g++ && \
+    npm install -g pm2 && \
+    npm install -g sequelize && \
+    npm install && \
+    apk del build-dependencies && \
+    rm -rf /root && \
+    apk --no-cache add curl
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 COPY . .
-RUN mkdir lib
-RUN npm run build
+RUN mkdir lib && \
+    npm run build
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ npm install -g @idexio/idexd-cli
 ```
 idex config
 ```
-IDEXd provides prompts asking for a staking wallet that contains at least 10,000 IDEX for 7 days. Go to [MyEtherWallet](https://www.myetherwallet.com/interface/sign-message) or your preferred wallet software to sign the challenge and provide the `sig` value to prove that you control the wallet.
+IDEXd provides prompts asking for a staking wallet that contains at least 10,000 IDEX for 7 days. Go to [MyEtherWallet](https://vintage.myetherwallet.com/signmsg.html) or your preferred wallet software to sign the challenge and provide the `sig` value to prove that you control the wallet.
 
 IDEXd employs a cold-wallet design so that staked funds never need to leave the staking wallet for maximum security.
 
@@ -270,7 +270,7 @@ idex start --rpc <RPC endpoint URL including port>
 
 ## Getting Help and Reporting Issues
 
-For questions about getting started and help if you're stuck, please [reach out to our team on Discord](https://discord.gg/tQa9CAB). 
+For questions about getting started and help if you're stuck, please [reach out to our team on Discord](https://discord.gg/tQa9CAB).
 
 If you believe you have identified a bug in IDEXd, please [file an issue](https://github.com/idexio/idexd/issues).
 

--- a/aurad-cli/package-lock.json
+++ b/aurad-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@idexio/idexd-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/aurad-cli/package.json
+++ b/aurad-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idexio/idexd-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "bin": {
     "idex": "./bin/run"
   },

--- a/aurad-cli/src/containers/docker/docker-compose.yml
+++ b/aurad-cli/src/containers/docker/docker-compose.yml
@@ -1,11 +1,14 @@
 version: '3.3'
-            
+
 services:
     parity:
         image: parity/parity:stable
+        container_name: parity
         env_file: aurad_config.env
         volumes:
-            - parity:/eth
+          - type: bind
+            source: ${HOME}/.idexd/eth
+            target: /eth
         command: ["--light", "--jsonrpc-interface=all", "--base-path", "/eth"]
         ports:
             - "127.0.0.1:8545:8545"
@@ -24,6 +27,7 @@ services:
         user: root
     mysql:
         image: mysql:5.7
+        container_name: mysql
         env_file: aurad_config.env
         volumes:
             - type: bind
@@ -35,6 +39,7 @@ services:
             - "127.0.0.1:33006:3306"
     idexd:
         image: idexio/idexd:0.2.0
+        container_name: idexd
         depends_on:
           - "mysql"
         volumes:
@@ -67,6 +72,7 @@ services:
           - "mysql:db.local"
     aurad:
         image: auroradao/aurad:0.1.4
+        container_name: aurad
         entrypoint: ["echo", "aurad is now idexd, exiting"]
 volumes:
   parity:

--- a/aurad-cli/src/shared/docker.js
+++ b/aurad-cli/src/shared/docker.js
@@ -16,7 +16,7 @@ module.exports = class Docker {
   constructor(rpcUrl) {
     this.rpcUrl = rpcUrl || 'http://parity:8545';
   }
-  
+
   env() {
     const rpc = url.parse(this.rpcUrl);
     const RPC_HOST = `${rpc.hostname}${rpc.pathname}`;
@@ -26,27 +26,28 @@ module.exports = class Docker {
     const SSL_PRIVATE_KEY_PATH = process.env.IS_STAGING === '1' ? 'ssl/staging/key.pem' : 'ssl/production/key.pem';
     return `HOME=${homedir} SSL_CERT_PATH=${SSL_CERT_PATH} SSL_PRIVATE_KEY_PATH=${SSL_PRIVATE_KEY_PATH} RPC_HOST=${RPC_HOST} RPC_PROTOCOL=${RPC_PROTOCOL} RPC_PORT=${RPC_PORT} STAKING_HOST=${STAKING_HOST}`;
   }
-  
+
   rpcIsCustom() {
     return (this.rpcUrl !== 'http://parity:8545');
   }
-  
+
   async ensureDirs() {
     await mkdirp(`${homedir}/.idexd`);
     await this.migrateDirs();
     const dirs = [
       `${homedir}/.idexd/db`,
       `${homedir}/.idexd/ipc`,
-      `${homedir}/.idexd/downloads`
+      `${homedir}/.idexd/downloads`,
+      `${homedir}/.idexd/eth`
     ];
-    
+
     await Promise.map(dirs, dir => mkdirp(dir));
 
     if (process.getuid && process.getuid() === 0) {
       console.warn('[WARNING] running `idex` as root is not recommended');
     }
   }
-  
+
   async migrateDirs() {
     if (fs.existsSync(`${homedir}/.aurad`)) {
       const runningContainers = await this.getRunningContainerIds();
@@ -67,7 +68,7 @@ module.exports = class Docker {
       }
     }
   }
-  
+
   async requireDocker() {
     try {
       let [dockerCmd, dockerVersion] = await this.hasDocker();
@@ -83,11 +84,11 @@ module.exports = class Docker {
       process.exit(1);
     }
   }
-  
+
   composeFile() {
     return `${__dirname}/../containers/docker/docker-compose.yml`;
   }
-  
+
   statusFile() {
     return `${homedir}/.idexd/ipc/status.json`;
   }
@@ -97,25 +98,25 @@ module.exports = class Docker {
     let {stdout} = await exec(`${this.env()} ${cmd} -f ${this.composeFile()} pull ${services.join(' ')}`);
     return(stdout);
   }
-    
+
   async up(services = ['parity', 'mysql', 'idexd']) {
     this.ensureDirs();
-    
+
     let [cmd, version] = await this.hasCompose();
-    
+
     // only parity, but we're not using it
     if (this.rpcIsCustom() === true) {
       services = services.filter(s => s !== 'parity');
     }
-    
+
     if (services.length === 0) return;
-    
+
     await this.pull(services);
-    
+
     let {stdout} = await exec(`${this.env()} ${cmd} -f ${this.composeFile()} up -d ${services.join(' ')}`);
     return(stdout);
   }
-  
+
   async down() {
     let [cmd, version] = await this.hasCompose();
     let [dcmd, dversion] = await this.hasDocker();
@@ -155,33 +156,33 @@ module.exports = class Docker {
     let {stdout} = await exec(`${cmd} -f ${this.composeFile()} down`);
     return(stdout);
   }
-  
+
   async getRunningContainerIds() {
     let [cmd, version] = await this.hasCompose();
     let ids = {};
     let result = await exec (`${cmd} -f ${this.composeFile()} ps -q mysql`);
-    ids['mysql'] = result.stdout.toString().split('\n')[0];    
+    ids['mysql'] = result.stdout.toString().split('\n')[0];
     result = await exec (`${cmd} -f ${this.composeFile()} ps -q parity`);
-    ids['parity'] = result.stdout.toString().split('\n')[0]; 
+    ids['parity'] = result.stdout.toString().split('\n')[0];
     result = await exec (`${cmd} -f ${this.composeFile()} ps -q aurad`);
-    ids['aurad'] = result.stdout.toString().split('\n')[0]; 
+    ids['aurad'] = result.stdout.toString().split('\n')[0];
     result = await exec (`${cmd} -f ${this.composeFile()} ps -q idexd`);
-    ids['idexd'] = result.stdout.toString().split('\n')[0]; 
+    ids['idexd'] = result.stdout.toString().split('\n')[0];
     return(ids);
   }
-  
+
   async getContainerLogs(app) {
     let [cmd, version] = await this.hasDocker();
     let {stdout, stderr} = await exec (`${cmd} logs --tail 10000 ${app}`, {maxBuffer: 1024*1024*10});
     return(stdout == '' ? stderr : stdout);
   }
-  
+
   async dbMigrate() {
-    let [cmd, version] = await this.hasCompose();    
+    let [cmd, version] = await this.hasCompose();
     const {stdio} = await exec(`${cmd} -f ${this.composeFile()} run --entrypoint /usr/idexd/node_modules/.bin/sequelize idexd db:migrate`);
     return(stdio);
   }
-  
+
   async dbRunning(app) {
     let [cmd, version] = await this.hasDocker();
     try {
@@ -191,12 +192,12 @@ module.exports = class Docker {
       return(false);
     }
   }
-    
+
   async dbShutdown(app)  {
     let [cmd, version] = await this.hasDocker();
     const result = await exec(`${cmd} exec ${app} mysqladmin -uroot --password=${process.env.MYSQL_ROOT_PASSWORD} shutdown`);
   }
-  
+
   async hasDocker() {
     try {
       let cmd = await commandExists('docker');
@@ -206,7 +207,7 @@ module.exports = class Docker {
       return(false);
     }
   }
-    
+
   async hasCompose() {
     try {
       let cmd = await commandExists('docker-compose');


### PR DESCRIPTION
That PR contains:
- Minified docker image based on node-alpine, image size dramatically decreased from `1.2G` to `241M`
- Change myetherwallet sign-message url
- Parity container now using its own data dir `${HOME}/.idexd/eth`, before there was unnamed volume which mounts to `/var/lib/docker/.../` (so container removing leads to volume destroy)
- Fixed container names (`idexd, parity, mysql`)