### PR TITLE
Parity can't sync anymore

### DIFF
--- a/aurad-cli/src/containers/docker/docker-compose.yml
+++ b/aurad-cli/src/containers/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
             
 services:
     parity:
-        image: parity/parity:stable
+        image: parity/parity:v2.5.9-stable
         env_file: aurad_config.env
         volumes:
             - parity:/eth


### PR DESCRIPTION
Using that specific version fix the issue (would love to see the latest stable version supported, I'll use that one as a temporary one)

Fixes #17 